### PR TITLE
Launch

### DIFF
--- a/.github/workflows/repo2docker.yml
+++ b/.github/workflows/repo2docker.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - name: repo2docker install
-        run: pip install --upgrade jupyter-repo2docker
+        run: |
+          pip install six
+          pip install --upgrade jupyter-repo2docker
       - name: Build container
         run: repo2docker --no-run .

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
+# Jupyter Desktop
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ITeMP-temp/Neo4J-graph/main?urlpath=desktop)
 # Neo4J-graph
 Repository for Neo4J graph database
 
 1. data - data folder containing all the data files for the neo4j database
-1. db-connection.py - Python script using Neo4J for connecting to local DB and storing data in it.
+1. connection.py - Python script using Neo4J for connecting to local DB and storing data in it.
 
 
-To run the notebooks or the scripts, you can either build locally with [repo2docker](https://repo2docker.readthedocs.io/) or [run on mybinder.org](https://mybinder.org/v2/gh/ITeMP-temp/Neo4J-graph/main?filepath=notebooks)
+To run the database, you can either build locally with [repo2docker](https://repo2docker.readthedocs.io/) or [run on mybinder.org](https://mybinder.org/v2/gh/ITeMP-temp/Neo4J-graph/main?urlpath=desktop)
 
 To build locally:
 

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -4,8 +4,10 @@ channels:
 - defaults
 dependencies:
 - openjdk=11
-- neo4j-python-driver
 - pandas
+- tqdm
 - jupyter-server-proxy
 - websockify
 - pip
+- pip:
+   - py2neo

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -57,10 +57,18 @@ rm neo4j-community-${VERSION}-unix.tar.gz
 # and you will be required to update the original default password 
 ${CONDA_DIR}/neo4j-community/bin/neo4j-admin set-initial-password neo4jbinder
 
-cp -R data ${CONDA_DIR}/neo4j-community/import
-
 # configure
 CONF_FILE=${CONDA_DIR}/neo4j-community/conf/neo4j.conf
 echo 'dbms.memory.heap.initial_size=512m' >> $CONF_FILE
 echo 'dbms.memory.heap.max_size=512m' >> $CONF_FILE
 echo "dbms.connectors.default_listen_address=0.0.0.0" >> $CONF_FILE
+
+# populate the neo4j DB
+
+(${CONDA_DIR}/neo4j-community/bin/neo4j start && sleep 20) | grep "Started neo4j"
+
+export PATH=/srv/conda/notebook/bin:$PATH
+python $HOME/src/amr-script.py -d neo4j
+python $HOME/src/mic-script.py -d neo4j
+
+${CONDA_DIR}/neo4j-community/bin/neo4j stop

--- a/binder/start
+++ b/binder/start
@@ -4,12 +4,7 @@ set -eux
 
 ln -s "$CONDA_DIR/vnc/Desktop"
 
-# populate the neo4j DB
 # start neo4j
-(${CONDA_DIR}/neo4j-community/bin/neo4j start && sleep 20) | grep "Started neo4j"
-
-export PATH=/srv/conda/notebook/bin:$PATH
-python ~/src/amr-script.py -d neo4j
-python ~/src/mic-script.py -d neo4j
+${CONDA_DIR}/neo4j-community/bin/neo4j start
 
 exec "$@"

--- a/binder/start
+++ b/binder/start
@@ -9,10 +9,7 @@ ln -s "$CONDA_DIR/vnc/Desktop"
 (${CONDA_DIR}/neo4j-community/bin/neo4j start && sleep 20) | grep "Started neo4j"
 
 export PATH=/srv/conda/notebook/bin:$PATH
-#set +eu
-#source /srv/conda/bin/activate notebook
-python ~/src/amr-script.py
-python ~/src/mic-script.py
+python ~/src/amr-script.py -d neo4j
+python ~/src/mic-script.py -d neo4j
 
-#set -eu
 exec "$@"

--- a/src/amr-script.py
+++ b/src/amr-script.py
@@ -5,11 +5,11 @@ import pandas as pd
 from tqdm import tqdm
 
 from py2neo import Node, Relationship
-from py2neo.database.work import Transaction
+from py2neo.database import Transaction
 
 from constants import DATA_DIR
-from connection import populate_db
-
+from connection import commit, populate_db
+import sys, getopt
 
 def map_data(
     data_df: pd.DataFrame
@@ -260,9 +260,20 @@ def add_skill_data(tx: Transaction, node_mapping_dict: dict):
         tx.create(includes)
 
 
-def main():
-    tx = populate_db(db_name='amrtest')
-
+def main(argv):
+    db_name = "amrtest"
+    try:
+        opts, args = getopt.getopt(argv,"hd:",["db="])
+    except getopt.GetoptError:
+        print('amr-script -id <dbname>')
+        sys.exit(2)
+    for opt, arg in opts:
+        if opt == '-h':
+            print('amr-script -d <dbname>')
+            sys.exit()
+        elif opt in ("-d", "--db"):
+            db_name = arg
+    tx = populate_db(db_name=db_name)
     df = pd.read_csv(
         os.path.join(DATA_DIR, 'AMR', 'person.csv'),
         usecols=[
@@ -297,9 +308,8 @@ def main():
         tx=tx,
         node_mapping_dict=node_map
     )
-
-    tx.commit()
+    commit(db_name, tx)
 
 
 if __name__ == '__main__':
-    main()
+    main(sys.argv[1:])

--- a/src/connection.py
+++ b/src/connection.py
@@ -3,15 +3,16 @@
 import logging
 
 from py2neo import Graph, SystemGraph
-from py2neo.database.work import ClientError
+from py2neo.errors import ClientError
+from py2neo.database import Transaction
 
-from constants import ADMIN_NAME, ADMIN_PASS
+from constants import ADMIN_NAME, ADMIN_PASS, URL
 
 logger = logging.getLogger()
 logging.basicConfig(level=logging.INFO)
 
 system_graph = SystemGraph(
-    'bolt://localhost:7687',
+    URL,
     auth=(ADMIN_NAME, ADMIN_PASS)
 )
 
@@ -63,10 +64,18 @@ def populate_db(db_name: str):
     assert in_db is True
 
     conn = Graph(
-        'bolt://localhost:7687',
+        URL,
         auth=(ADMIN_NAME, ADMIN_PASS),
         name=db_name
     )
 
     tx = conn.begin()
     return tx
+
+def commit(db_name: str, tx: Transaction):
+    conn = Graph(
+        URL,
+        auth=(ADMIN_NAME, ADMIN_PASS),
+        name=db_name
+    )
+    conn.commit(tx)

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,0 +1,4 @@
+DATA_DIR = "~/data/"
+ADMIN_NAME = "neo4j"
+ADMIN_PASS = "neo4jbinder"
+URL = 'bolt://localhost:7687'

--- a/src/mic-script.py
+++ b/src/mic-script.py
@@ -5,10 +5,11 @@ import pandas as pd
 from tqdm import tqdm
 
 from py2neo import Node, Relationship
-from py2neo.database.work import Transaction
+from py2neo.database import Transaction
 
 from constants import DATA_DIR
-from connection import populate_db
+from connection import commit, populate_db
+import sys, getopt
 
 
 def create_nodes(tx: Transaction, data: pd.DataFrame):
@@ -141,8 +142,21 @@ def create_relations(
             tx.create(in_year)
 
 
-def main():
-    tx = populate_db(db_name='micdata')
+def main(argv):
+    db_name = "micdata"
+    try:
+        opts, args = getopt.getopt(argv,"hd:",["db="])
+    except getopt.GetoptError:
+        print('mic-script -id <dbname>')
+        sys.exit(2)
+    for opt, arg in opts:
+        if opt == '-h':
+            print('mic-script -id <dbname>')
+            sys.exit()
+        elif opt in ("-d", "--db"):
+            db_name = arg
+
+    tx = populate_db(db_name=db_name)
 
     data_df = pd.read_csv(
         os.path.join(DATA_DIR, 'MIC', 'mic-data.tsv'),
@@ -172,8 +186,8 @@ def main():
         node_map=node_mapping_dict
     )
 
-    tx.commit()
+    commit(db_name, tx)
 
 
 if __name__ == '__main__':
-    main()
+    main(sys.argv[1:])


### PR DESCRIPTION
This PR:
* Updates the URL to use in binder to launch the desktop by default
* Installs the dependencies required to run the script
* Updates the script to work with newer version of ``py2neo``
* Modifies the script so the db name can be specified. ``neo4j-community`` edition does not allow to create a DB so the default one is used i.e. neo4j. We could change that name if we want in the neo4j config file

To test the URL: do not click on the link in the readme (This will only work when this PR is merged) but use 
https://mybinder.org/v2/gh/jburel/Neo4J-graph/launch?urlpath=desktop

~Edit: Populating the DB when starting up works locally but not on mybinder.org~
~I have not yet found the source of the problem.~
29aea7ce0aa36c33cc1614cc0f6f5c65ea8b5524 fixes the issue above. It is now working.


cc @YojanaGadiya @agiani99 